### PR TITLE
Remove testing against stable-2.9 and stable-2.10 from GHA matrix

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
@@ -54,8 +52,6 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13


### PR DESCRIPTION
##### SUMMARY
Remove testing against stable-2.9 and stable-2.10 from GHA matrix as they are EOL